### PR TITLE
Adding support for multiple timezones

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ This is my first ever Connect IQ watch face (please be kind!), so I look forward
 
 ## What's New
 
+### 1.9.0
+- Added ability to display 2 or 4 configurable world timezones on a variety of watches
+
 ### 1.8.0
 - Added setting to control number of data fields (0-3).
 - Added setting to control number of indicators (0-3): Bluetooth, alarms, notifications, bluetooth/notifications.

--- a/monkey.jungle
+++ b/monkey.jungle
@@ -1,7 +1,9 @@
 project.manifest = manifest.xml
 
+round-240x240.resourcePath = $(round-240x240.resourcePath);resources-worldtime
+
 # Smaller round watches use small time font.
-round-218x218.resourcePath = $(round-218x218.resourcePath);resources-small-time
+round-218x218.resourcePath = $(round-218x218.resourcePath);resources-small-time;resources-worldtime
 
 # Flat tyre watches use small time font and small icons.
 semiround-215x180.resourcePath = $(semiround-215x180.resourcePath);resources-small-time;resources-small-icons
@@ -27,13 +29,13 @@ fenix3.excludeAnnotations = buffered
 fenix3_hr.resourcePath = $(fenix3_hr.resourcePath);resources-round-218x218-ciq_1.x;resources-ciq_1.x
 fenix3_hr.excludeAnnotations = buffered
 
-fr230.resourcePath = $(fr230.resourcePath);resources-semiround-215x180-ciq_1.x;resources-ciq_1.x-no_hr
+fr230.resourcePath = $(fr230.resourcePath);resources-semiround-215x180-ciq_1.x;resources-ciq_1.x-no_hr;resources-worldtime
 fr230.excludeAnnotations = buffered
 
-fr235.resourcePath = $(fr235.resourcePath);resources-semiround-215x180-ciq_1.x;resources-ciq_1.x
+fr235.resourcePath = $(fr235.resourcePath);resources-semiround-215x180-ciq_1.x;resources-ciq_1.x;resources-worldtime
 fr235.excludeAnnotations = buffered
 
-fr630.resourcePath = $(fr630.resourcePath);resources-semiround-215x180-ciq_1.x;resources-ciq_1.x-no_hr
+fr630.resourcePath = $(fr630.resourcePath);resources-semiround-215x180-ciq_1.x;resources-ciq_1.x-no_hr;resources-worldtime
 fr630.excludeAnnotations = buffered
 
 fr920xt.resourcePath = $(fr920xt.resourcePath);resources-ciq_1.x-no_hr
@@ -47,4 +49,7 @@ vivoactive.excludeAnnotations = buffered
 # #21: Treat fr735xt as CIQ 1.x i.e. unbuffered drawing, due to insufficient memory.
 # Continue to use fr735xt-specific properties and settings, however, as does support active minutes.
 fr735xt.resourcePath = $(fr735xt.resourcePath);resources-semiround-215x180-ciq_1.x
-fr735xt.excludeAnnotations = buffered
+#fr735xt.resourcePath = $(fr735xt.resourcePath)
+fr735xt.excludeAnnotations = buffered;timezones
+
+vivoactive_hr.excludeAnnotations = timezones

--- a/resources-rectangle-148x205/layouts/layout.xml
+++ b/resources-rectangle-148x205/layouts/layout.xml
@@ -30,8 +30,8 @@
 		<param name="right">115</param>
 		<param name="top">11</param>
 		<param name="bottom">30</param>
-		<param name="batteryFillWidth">24</param>
-		<param name="batteryFillHeight">12</param>
+		<param name="batteryWidth">24</param>
+		<param name="batteryHeight">12</param>
 	</drawable>
 
 	<drawable id="Date" class="DateLine">

--- a/resources-round-218x218-ciq_1.x/layouts/layout.xml
+++ b/resources-round-218x218-ciq_1.x/layouts/layout.xml
@@ -1,72 +1,153 @@
-<layout id="WatchFace">
-	<drawable class="Background" />
+<resources>
+	<layout id="WatchFace">
+		<drawable class="Background" />
 
-	<drawable id="LeftGoalMeter" class="GoalMeter">
-		<param name="side">:left</param>
-		<param name="shape">:arc</param>
-		<param name="stroke">8</param>
-		<param name="height">138</param>
-		<param name="separator">2</param>
-	</drawable>
+		<drawable id="LeftGoalMeter" class="GoalMeter">
+			<param name="side">:left</param>
+			<param name="shape">:arc</param>
+			<param name="stroke">8</param>
+			<param name="height">138</param>
+			<param name="separator">2</param>
+		</drawable>
 
-	<drawable id="RightGoalMeter" class="GoalMeter">
-		<param name="side">:right</param>
-		<param name="shape">:arc</param>
-		<param name="stroke">8</param>
-		<param name="height">138</param>
-		<param name="separator">2</param>
-	</drawable>
+		<drawable id="RightGoalMeter" class="GoalMeter">
+			<param name="side">:right</param>
+			<param name="shape">:arc</param>
+			<param name="stroke">8</param>
+			<param name="height">138</param>
+			<param name="separator">2</param>
+		</drawable>
 
-	<!-- Mask required for goal meter drawing without clip support -->
-	<drawable class="GoalMeterMask">
-		<param name="stroke">8</param>
-	</drawable>
+		<!-- Mask required for goal meter drawing without clip support -->
+		<drawable class="GoalMeterMask">
+			<param name="stroke">8</param>
+		</drawable>
 
-	<label id="LeftGoalIcon" text="0" x="40" y="166" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_LEFT"/>
-	<label id="LeftGoalCurrent" text="3500" x="67" y="170" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
-	<label id="LeftGoalMax" text="5000" x="67" y="186" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="LeftGoalIcon" text="0" x="40" y="166" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_LEFT"/>
+		<label id="LeftGoalCurrent" text="3500" x="67" y="170" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="LeftGoalMax" text="5000" x="67" y="186" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
 
-	<label id="RightGoalIcon" text="1" x="178" y="166" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_RIGHT"/>
-	<label id="RightGoalCurrent" text="6" x="151" y="170" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
-	<label id="RightGoalMax" text="10" x="151" y="186" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="RightGoalIcon" text="1" x="178" y="166" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_RIGHT"/>
+		<label id="RightGoalCurrent" text="6" x="151" y="170" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="RightGoalMax" text="10" x="151" y="186" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
 
-	<drawable id="DataFields" class="DataFields">
-		<param name="left">69</param>
-		<param name="right">149</param>
-		<param name="top">24</param>
-		<param name="bottom">45</param>
-		<param name="batteryWidth">28</param>
-		<param name="batteryHeight">14</param>
-	</drawable>
+		<drawable id="DataFields" class="DataFields">
+			<param name="left">69</param>
+			<param name="right">149</param>
+			<param name="top">24</param>
+			<param name="bottom">45</param>
+			<param name="batteryWidth">28</param>
+			<param name="batteryHeight">14</param>
+		</drawable>
 
-	<drawable id="Date" class="DateLine">
-		<param name="y">70</param>
-	</drawable>
+		<drawable id="Date" class="DateLine">
+			<param name="y">70</param>
+		</drawable>
 
-	<drawable id="Indicators" class="Indicators">
-		<param name="locX">31</param>
-		<param name="locY">109</param>
-		<param name="spacingY">30</param>
-		<param name="batteryWidth">24</param>
-		<param name="batteryHeight">12</param>
-	</drawable>
+		<drawable id="Indicators" class="Indicators">
+			<param name="locX">31</param>
+			<param name="locY">109</param>
+			<param name="spacingY">30</param>
+			<param name="batteryWidth">24</param>
+			<param name="batteryHeight">12</param>
+		</drawable>
 
-	<drawable id="Time" class="ThickThinTime">
-		<param name="secondsX">147</param>
-		<param name="secondsY">129</param>
+		<drawable id="Time" class="ThickThinTime">
+			<param name="ampmY">109</param>
+			<param name="secondsX">147</param>
+			<param name="secondsY">129</param>
 
-		<!-- Partial updates not supported -->	
-		<!--param name="secondsClipY">139</param-->
-		<!--param name="secondsClipWidth">22</param-->
-		<!--param name="secondsClipHeight">15</param-->
-	</drawable>
+			<!-- Partial updates not supported -->	
+			<!--param name="secondsClipY">139</param-->
+			<!--param name="secondsClipWidth">22</param-->
+			<!--param name="secondsClipHeight">15</param-->
+		</drawable>
 
-	<drawable id="MoveBar" class="MoveBar">
-		<param name="x">50</param>
-		<param name="y">146</param>
-		<param name="width">90</param>
-		<param name="height">9</param>
-		<param name="separator">3</param>
-	</drawable>
+		<drawable id="MoveBar" class="MoveBar">
+			<param name="x">50</param>
+			<param name="y">146</param>
+			<param name="width">90</param>
+			<param name="height">9</param>
+			<param name="separator">3</param>
+		</drawable>
 	
-</layout>
+	</layout>
+	<layout id="WatchFaceTZ">
+		<drawable class="Background" />
+
+		<drawable id="LeftGoalMeter" class="GoalMeter">
+			<param name="side">:left</param>
+			<param name="shape">:arc</param>
+			<param name="stroke">8</param>
+			<param name="height">138</param>
+			<param name="separator">2</param>
+		</drawable>
+
+		<drawable id="RightGoalMeter" class="GoalMeter">
+			<param name="side">:right</param>
+			<param name="shape">:arc</param>
+			<param name="stroke">8</param>
+			<param name="height">138</param>
+			<param name="separator">2</param>
+		</drawable>
+
+		<!-- Mask required for goal meter drawing without clip support -->
+		<drawable class="GoalMeterMask">
+			<param name="stroke">8</param>
+		</drawable>
+
+		<label id="LeftGoalIcon" text="0" x="40" y="166" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_LEFT"/>
+		<label id="LeftGoalCurrent" text="3500" x="67" y="170" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="LeftGoalMax" text="5000" x="67" y="186" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+
+		<label id="RightGoalIcon" text="1" x="178" y="166" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_RIGHT"/>
+		<label id="RightGoalCurrent" text="6" x="151" y="170" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="RightGoalMax" text="10" x="151" y="186" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+
+		<drawable id="DataFields" class="DataFields">
+			<param name="left">69</param>
+			<param name="right">149</param>
+			<param name="top">24</param>
+			<param name="bottom">45</param>
+			<param name="batteryWidth">28</param>
+			<param name="batteryHeight">14</param>
+		</drawable>
+
+		<drawable id="Date" class="DateLine">
+			<param name="y">62</param>
+		</drawable>
+
+		<drawable id="Indicators" class="Indicators">
+			<param name="locX">31</param>
+			<param name="locY">109</param>
+			<param name="spacingY">30</param>
+			<param name="batteryWidth">24</param>
+			<param name="batteryHeight">12</param>
+		</drawable>
+
+		<drawable id="Time" class="ThickThinTime">
+			<param name="ampmY">109</param>	
+			<param name="secondsX">0</param>
+			<param name="secondsY">110</param>
+
+			<!-- Partial updates not supported -->	
+			<!--param name="secondsClipY">139</param-->
+			<!--param name="secondsClipWidth">22</param-->
+			<!--param name="secondsClipHeight">15</param-->
+		</drawable>
+
+		<drawable id="Timezones" class="Timezones">
+			<param name="topY">81</param>
+			<param name="bottomY">140</param>
+		</drawable>
+
+		<drawable id="MoveBar" class="MoveBar">
+			<param name="x">50</param>
+			<param name="y">160</param>
+			<param name="width">118</param>
+			<param name="height">9</param>
+			<param name="separator">3</param>
+		</drawable>
+	
+	</layout>
+</resources>

--- a/resources-round-218x218/layouts/layout.xml
+++ b/resources-round-218x218/layouts/layout.xml
@@ -1,65 +1,139 @@
-<layout id="WatchFace">
-	<drawable class="Background" />
+<resources>
+	<layout id="WatchFace">
+		<drawable class="Background" />
 
-	<drawable id="LeftGoalMeter" class="GoalMeter">
-		<param name="side">:left</param>
-		<param name="shape">:arc</param>
-		<param name="stroke">8</param>
-		<param name="height">138</param>
-		<param name="separator">2</param>
-	</drawable>
+		<drawable id="LeftGoalMeter" class="GoalMeter">
+			<param name="side">:left</param>
+			<param name="shape">:arc</param>
+			<param name="stroke">8</param>
+			<param name="height">138</param>
+			<param name="separator">2</param>
+		</drawable>
 
-	<drawable id="RightGoalMeter" class="GoalMeter">
-		<param name="side">:right</param>
-		<param name="shape">:arc</param>
-		<param name="stroke">8</param>
-		<param name="height">138</param>
-		<param name="separator">2</param>
-	</drawable>
+		<drawable id="RightGoalMeter" class="GoalMeter">
+			<param name="side">:right</param>
+			<param name="shape">:arc</param>
+			<param name="stroke">8</param>
+			<param name="height">138</param>
+			<param name="separator">2</param>
+		</drawable>
 
-	<label id="LeftGoalIcon" text="0" x="40" y="166" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_LEFT"/>
-	<label id="LeftGoalCurrent" text="3500" x="67" y="170" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
-	<label id="LeftGoalMax" text="5000" x="67" y="186" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="LeftGoalIcon" text="0" x="40" y="166" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_LEFT"/>
+		<label id="LeftGoalCurrent" text="3500" x="67" y="170" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="LeftGoalMax" text="5000" x="67" y="186" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
 
-	<label id="RightGoalIcon" text="1" x="178" y="166" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_RIGHT"/>
-	<label id="RightGoalCurrent" text="6" x="151" y="170" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
-	<label id="RightGoalMax" text="10" x="151" y="186" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="RightGoalIcon" text="1" x="178" y="166" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_RIGHT"/>
+		<label id="RightGoalCurrent" text="6" x="151" y="170" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="RightGoalMax" text="10" x="151" y="186" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
 
-	<drawable id="DataFields" class="DataFields">
-		<param name="left">69</param>
-		<param name="right">149</param>
-		<param name="top">24</param>
-		<param name="bottom">45</param>
-		<param name="batteryWidth">28</param>
-		<param name="batteryHeight">14</param>
-	</drawable>
+		<drawable id="DataFields" class="DataFields">
+			<param name="left">69</param>
+			<param name="right">149</param>
+			<param name="top">24</param>
+			<param name="bottom">45</param>
+			<param name="batteryWidth">28</param>
+			<param name="batteryHeight">14</param>
+		</drawable>
 
-	<drawable id="Date" class="DateLine">
-		<param name="y">70</param>
-	</drawable>
+		<drawable id="Date" class="DateLine">
+			<param name="y">70</param>
+		</drawable>
 
-	<drawable id="Indicators" class="Indicators">
-		<param name="locX">31</param>
-		<param name="locY">109</param>
-		<param name="spacingY">30</param>
-		<param name="batteryWidth">24</param>
-		<param name="batteryHeight">12</param>
-	</drawable>
+		<drawable id="Indicators" class="Indicators">
+			<param name="locX">31</param>
+			<param name="locY">109</param>
+			<param name="spacingY">30</param>
+			<param name="batteryWidth">24</param>
+			<param name="batteryHeight">12</param>
+		</drawable>
 
-	<drawable id="Time" class="ThickThinTime">
-		<param name="secondsX">147</param>
-		<param name="secondsY">129</param>		
-		<param name="secondsClipY">139</param>
-		<param name="secondsClipWidth">22</param>
-		<param name="secondsClipHeight">15</param>
-	</drawable>
+		<drawable id="Time" class="ThickThinTime">
+			<param name="ampmY">109</param>
+			<param name="secondsX">147</param>
+			<param name="secondsY">129</param>		
+			<param name="secondsClipY">139</param>
+			<param name="secondsClipWidth">22</param>
+			<param name="secondsClipHeight">15</param>
+		</drawable>
 
-	<drawable id="MoveBar" class="MoveBar">
-		<param name="x">50</param>
-		<param name="y">146</param>
-		<param name="width">90</param>
-		<param name="height">9</param>
-		<param name="separator">3</param>
-	</drawable>
+		<drawable id="MoveBar" class="MoveBar">
+			<param name="x">50</param>
+			<param name="y">146</param>
+			<param name="width">90</param>
+			<param name="height">9</param>
+			<param name="separator">3</param>
+		</drawable>
 	
-</layout>
+	</layout>
+	<layout id="WatchFaceTZ">
+		<drawable class="Background" />
+
+		<drawable id="LeftGoalMeter" class="GoalMeter">
+			<param name="side">:left</param>
+			<param name="shape">:arc</param>
+			<param name="stroke">8</param>
+			<param name="height">138</param>
+			<param name="separator">2</param>
+		</drawable>
+
+		<drawable id="RightGoalMeter" class="GoalMeter">
+			<param name="side">:right</param>
+			<param name="shape">:arc</param>
+			<param name="stroke">8</param>
+			<param name="height">138</param>
+			<param name="separator">2</param>
+		</drawable>
+
+		<label id="LeftGoalIcon" text="0" x="40" y="166" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_LEFT"/>
+		<label id="LeftGoalCurrent" text="3500" x="67" y="170" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="LeftGoalMax" text="5000" x="67" y="186" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+
+		<label id="RightGoalIcon" text="1" x="178" y="166" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_RIGHT"/>
+		<label id="RightGoalCurrent" text="6" x="151" y="170" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="RightGoalMax" text="10" x="151" y="186" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+
+		<drawable id="DataFields" class="DataFields">
+			<param name="left">69</param>
+			<param name="right">149</param>
+			<param name="top">24</param>
+			<param name="bottom">45</param>
+			<param name="batteryWidth">28</param>
+			<param name="batteryHeight">14</param>
+		</drawable>
+
+		<drawable id="Date" class="DateLine">
+			<param name="y">62</param>
+		</drawable>
+
+		<drawable id="Indicators" class="Indicators">
+			<param name="locX">31</param>
+			<param name="locY">109</param>
+			<param name="spacingY">30</param>
+			<param name="batteryWidth">24</param>
+			<param name="batteryHeight">12</param>
+		</drawable>
+
+		<drawable id="Time" class="ThickThinTime">
+			<param name="ampmY">99</param>
+			<param name="secondsX">0</param>
+			<param name="secondsY">105</param>		
+			<param name="secondsClipY">115</param>
+			<param name="secondsClipWidth">22</param>
+			<param name="secondsClipHeight">15</param>
+		</drawable>
+
+		<drawable id="Timezones" class="Timezones">
+			<param name="topY">81</param>
+			<param name="bottomY">140</param>
+		</drawable>
+
+		<drawable id="MoveBar" class="MoveBar">
+			<param name="x">50</param>
+			<param name="y">159</param>
+			<param name="width">118</param>
+			<param name="height">7</param>
+			<param name="separator">3</param>
+		</drawable>
+	
+	</layout>
+</resources>

--- a/resources-semiround-215x180-ciq_1.x/layouts/layout.xml
+++ b/resources-semiround-215x180-ciq_1.x/layouts/layout.xml
@@ -1,3 +1,4 @@
+<resources>
 <layout id="WatchFace">
 	<drawable class="Background" />
 
@@ -52,6 +53,7 @@
 	</drawable>
 
 	<drawable id="Time" class="ThickThinTime">
+		<param name="ampmY">90</param>
 		<param name="secondsX">145</param>
 		<param name="secondsY">109</param>
 		
@@ -70,3 +72,82 @@
 	</drawable>
 	
 </layout>
+<layout id="WatchFaceTZ">
+	<drawable class="Background" />
+
+	<drawable id="LeftGoalMeter" class="GoalMeter">
+		<param name="side">:left</param>
+		<param name="shape">:arc</param>
+		<param name="stroke">6</param>
+		<param name="height">180</param>
+		<param name="separator">2</param>
+	</drawable>
+
+	<drawable id="RightGoalMeter" class="GoalMeter">
+		<param name="side">:right</param>
+		<param name="shape">:arc</param>
+		<param name="stroke">6</param>
+		<param name="height">180</param>
+		<param name="separator">2</param>
+	</drawable>
+
+	<!-- Mask required for goal meter drawing without clip support -->
+	<drawable class="GoalMeterMask">
+		<param name="stroke">6</param>
+	</drawable>
+
+	<label id="LeftGoalIcon" text="0" x="42" y="145" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_LEFT"/>
+	<label id="LeftGoalCurrent" text="3500" x="65" y="147" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+	<label id="LeftGoalMax" text="5000" x="65" y="163" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+
+	<label id="RightGoalIcon" text="1" x="173" y="145" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_RIGHT"/>
+	<label id="RightGoalCurrent" text="6" x="150" y="147" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+	<label id="RightGoalMax" text="10" x="150" y="163" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+
+	<drawable id="DataFields" class="DataFields">
+		<param name="left">68</param>
+		<param name="right">147</param>
+		<param name="top">13</param>
+		<param name="bottom">32</param>
+		<param name="batteryWidth">24</param>
+		<param name="batteryHeight">12</param>
+	</drawable>
+
+	<drawable id="Date" class="DateLine">
+		<param name="y">46</param>
+	</drawable>
+
+	<drawable id="Indicators" class="Indicators">
+		<param name="locX">28</param>
+		<param name="locY">90</param>
+		<param name="spacingY">28</param>
+		<param name="batteryWidth">20</param>
+		<param name="batteryHeight">10</param>
+	</drawable>
+
+	<drawable id="Time" class="ThickThinTime">
+		<param name="ampmY">90</param>
+		<param name="secondsX">145</param>
+		<param name="secondsY">109</param>
+		
+		<!-- Partial updates not supported -->		
+		<!-- param name="secondsClipY">117</param-->
+		<!-- param name="secondsClipWidth">22</param-->
+		<!-- param name="secondsClipHeight">15</param-->
+	</drawable>
+	
+	<drawable id="Timezones" class="Timezones">
+		<param name="topY">64</param>
+		<param name="bottomY">121</param>
+	</drawable>
+
+	<drawable id="MoveBar" class="MoveBar">
+		<param name="x">48</param>
+		<param name="y">136</param>
+		<param name="width">122</param>
+		<param name="height">7</param>
+		<param name="separator">3</param>
+	</drawable>
+	
+</layout>
+</resources>

--- a/resources-semiround-215x180/layouts/layout.xml
+++ b/resources-semiround-215x180/layouts/layout.xml
@@ -1,67 +1,143 @@
-<layout id="WatchFace">
-	<drawable class="Background" />
+<resources>
+	<layout id="WatchFace">
+		<drawable class="Background" />
 
-	<drawable id="LeftGoalMeter" class="GoalMeter">
-		<param name="side">:left</param>
-		<param name="shape">:arc</param>
-		<param name="stroke">6</param>
-		<param name="height">180</param>
-		<param name="separator">2</param>
-	</drawable>
+		<drawable id="LeftGoalMeter" class="GoalMeter">
+			<param name="side">:left</param>
+			<param name="shape">:arc</param>
+			<param name="stroke">6</param>
+			<param name="height">180</param>
+			<param name="separator">2</param>
+		</drawable>
 
-	<drawable id="RightGoalMeter" class="GoalMeter">
-		<param name="side">:right</param>
-		<param name="shape">:arc</param>
-		<param name="stroke">6</param>
-		<param name="height">180</param>
-		<param name="separator">2</param>
-	</drawable>
+		<drawable id="RightGoalMeter" class="GoalMeter">
+			<param name="side">:right</param>
+			<param name="shape">:arc</param>
+			<param name="stroke">6</param>
+			<param name="height">180</param>
+			<param name="separator">2</param>
+		</drawable>
 
-	<label id="LeftGoalIcon" text="0" x="42" y="145" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_LEFT"/>
-	<label id="LeftGoalCurrent" text="3500" x="65" y="147" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
-	<label id="LeftGoalMax" text="5000" x="65" y="163" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="LeftGoalIcon" text="0" x="42" y="145" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_LEFT"/>
+		<label id="LeftGoalCurrent" text="3500" x="65" y="147" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="LeftGoalMax" text="5000" x="65" y="163" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
 
-	<label id="RightGoalIcon" text="1" x="173" y="145" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_RIGHT"/>
-	<label id="RightGoalCurrent" text="6" x="150" y="147" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
-	<label id="RightGoalMax" text="10" x="150" y="163" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="RightGoalIcon" text="1" x="173" y="145" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_RIGHT"/>
+		<label id="RightGoalCurrent" text="6" x="150" y="147" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="RightGoalMax" text="10" x="150" y="163" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
 
-	<drawable id="DataFields" class="DataFields">
-		<param name="left">68</param>
-		<param name="right">147</param>
-		<param name="top">13</param>
-		<param name="bottom">32</param>
-		<param name="batteryWidth">24</param>
-		<param name="batteryHeight">12</param>
-	</drawable>
+		<drawable id="DataFields" class="DataFields">
+			<param name="left">68</param>
+			<param name="right">147</param>
+			<param name="top">13</param>
+			<param name="bottom">32</param>
+			<param name="batteryWidth">24</param>
+			<param name="batteryHeight">12</param>
+		</drawable>
 
-	<drawable id="Date" class="DateLine">
-		<param name="y">54</param>
-	</drawable>
+		<drawable id="Date" class="DateLine">
+			<param name="y">54</param>
+		</drawable>
 
-	<drawable id="Indicators" class="Indicators">
-		<param name="locX">28</param>
-		<param name="locY">90</param>
-		<param name="spacingY">28</param>
-		<param name="batteryWidth">20</param>
-		<param name="batteryHeight">10</param>
-	</drawable>
+		<drawable id="Indicators" class="Indicators">
+			<param name="locX">28</param>
+			<param name="locY">90</param>
+			<param name="spacingY">28</param>
+			<param name="batteryWidth">20</param>
+			<param name="batteryHeight">10</param>
+		</drawable>
 
-	<drawable id="Time" class="ThickThinTime">
-		<param name="secondsX">145</param>
-		<param name="secondsY">109</param>
+		<drawable id="Time" class="ThickThinTime">
+			<param name="ampmY">90</param>
+			<param name="secondsX">145</param>
+			<param name="secondsY">109</param>
 		
-		<!-- Partial updates not supported -->		
-		<!-- param name="secondsClipY">117</param-->
-		<!-- param name="secondsClipWidth">22</param-->
-		<!-- param name="secondsClipHeight">15</param-->
-	</drawable>
+			<!-- Partial updates not supported -->		
+			<!-- param name="secondsClipY">117</param-->
+			<!-- param name="secondsClipWidth">22</param-->
+			<!-- param name="secondsClipHeight">15</param-->
+		</drawable>
 
-	<drawable id="MoveBar" class="MoveBar">
-		<param name="x">48</param>
-		<param name="y">126</param>
-		<param name="width">87</param>
-		<param name="height">7</param>
-		<param name="separator">3</param>
-	</drawable>
+		<drawable id="MoveBar" class="MoveBar">
+			<param name="x">48</param>
+			<param name="y">126</param>
+			<param name="width">87</param>
+			<param name="height">7</param>
+			<param name="separator">3</param>
+		</drawable>
 	
-</layout>
+	</layout>
+	<layout id="WatchFaceTZ">
+		<drawable class="Background" />
+
+		<drawable id="LeftGoalMeter" class="GoalMeter">
+			<param name="side">:left</param>
+			<param name="shape">:arc</param>
+			<param name="stroke">6</param>
+			<param name="height">180</param>
+			<param name="separator">2</param>
+		</drawable>
+
+		<drawable id="RightGoalMeter" class="GoalMeter">
+			<param name="side">:right</param>
+			<param name="shape">:arc</param>
+			<param name="stroke">6</param>
+			<param name="height">180</param>
+			<param name="separator">2</param>
+		</drawable>
+
+		<label id="LeftGoalIcon" text="0" x="42" y="145" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_LEFT"/>
+		<label id="LeftGoalCurrent" text="3500" x="65" y="147" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="LeftGoalMax" text="5000" x="65" y="163" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+
+		<label id="RightGoalIcon" text="1" x="173" y="145" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_RIGHT"/>
+		<label id="RightGoalCurrent" text="6" x="150" y="147" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="RightGoalMax" text="10" x="150" y="163" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+
+		<drawable id="DataFields" class="DataFields">
+			<param name="left">68</param>
+			<param name="right">147</param>
+			<param name="top">13</param>
+			<param name="bottom">32</param>
+			<param name="batteryWidth">24</param>
+			<param name="batteryHeight">12</param>
+		</drawable>
+
+		<drawable id="Date" class="DateLine">
+			<param name="y">46</param>
+		</drawable>
+
+		<drawable id="Indicators" class="Indicators">
+			<param name="locX">28</param>
+			<param name="locY">90</param>
+			<param name="spacingY">28</param>
+			<param name="batteryWidth">20</param>
+			<param name="batteryHeight">10</param>
+		</drawable>
+
+		<drawable id="Time" class="ThickThinTime">
+			<param name="ampmY">90</param>
+			<param name="secondsX">145</param>
+			<param name="secondsY">109</param>
+		
+			<!-- Partial updates not supported -->		
+			<!-- param name="secondsClipY">117</param-->
+			<!-- param name="secondsClipWidth">22</param-->
+			<!-- param name="secondsClipHeight">15</param-->
+		</drawable>
+
+		<drawable id="Timezones" class="Timezones">
+			<param name="topY">64</param>
+			<param name="bottomY">121</param>
+		</drawable>	
+
+		<drawable id="MoveBar" class="MoveBar">
+			<param name="x">48</param>
+			<param name="y">136</param>
+			<param name="width">122</param>
+			<param name="height">7</param>
+			<param name="separator">3</param>
+		</drawable>
+	
+	</layout>
+</resources>

--- a/resources-worldtime/settings/properties.xml
+++ b/resources-worldtime/settings/properties.xml
@@ -1,0 +1,17 @@
+<properties>
+
+	<property id="timezones" type="number">4</property>
+	<property id="tz1_offset" type="number">0</property>
+	<property id="tz1_name" type="string">LON</property>
+	<property id="tz1_dst" type="boolean">true</property>
+	<property id="tz2_offset" type="number">8</property>
+	<property id="tz2_name" type="string">HKG</property>
+	<property id="tz2_dst" type="boolean">false</property>
+	<property id="tz3_offset" type="number">-8</property>
+	<property id="tz3_name" type="string">SFO</property>
+	<property id="tz3_dst" type="boolean">true</property>
+	<property id="tz4_offset" type="number">-5</property>
+	<property id="tz4_name" type="string">NYC</property>
+	<property id="tz4_dst" type="boolean">true</property>
+
+</properties>

--- a/resources-worldtime/settings/settings.xml
+++ b/resources-worldtime/settings/settings.xml
@@ -1,0 +1,163 @@
+<settings>
+
+	<setting propertyKey="@Properties.timezones" title="@Strings.timezones">
+		<settingConfig type="list">
+			<listEntry value="0">@Strings.zero</listEntry>
+			<listEntry value="2">@Strings.two</listEntry>
+			<listEntry value="4">@Strings.four</listEntry>
+		</settingConfig>
+	</setting>
+
+	<setting propertyKey="@Properties.tz1_offset" title="@Strings.tz1_offset">
+		<settingConfig type="list">
+			<listEntry value="-12">@Strings.minus_twelve</listEntry>
+			<listEntry value="-11">@Strings.minus_eleven</listEntry>
+			<listEntry value="-10">@Strings.minus_ten</listEntry>
+			<listEntry value="-9">@Strings.minus_nine</listEntry>
+			<listEntry value="-8">@Strings.minus_eight</listEntry>
+			<listEntry value="-7">@Strings.minus_seven</listEntry>
+			<listEntry value="-6">@Strings.minus_six</listEntry>
+			<listEntry value="-5">@Strings.minus_five</listEntry>
+			<listEntry value="-4">@Strings.minus_four</listEntry>
+			<listEntry value="-3">@Strings.minus_three</listEntry>
+			<listEntry value="-2">@Strings.minus_two</listEntry>
+			<listEntry value="-1">@Strings.minus_one</listEntry>
+			<listEntry value="0">@Strings.zero</listEntry>
+			<listEntry value="1">@Strings.plus_one</listEntry>
+			<listEntry value="2">@Strings.plus_two</listEntry>
+			<listEntry value="3">@Strings.plus_three</listEntry>
+			<listEntry value="4">@Strings.plus_four</listEntry>
+			<listEntry value="5">@Strings.plus_five</listEntry>
+			<listEntry value="6">@Strings.plus_six</listEntry>
+			<listEntry value="7">@Strings.plus_seven</listEntry>
+			<listEntry value="8">@Strings.plus_eight</listEntry>
+			<listEntry value="9">@Strings.plus_nine</listEntry>
+			<listEntry value="10">@Strings.plus_ten</listEntry>
+			<listEntry value="11">@Strings.plus_eleven</listEntry>
+			<listEntry value="12">@Strings.plus_twelve</listEntry>
+		</settingConfig>
+	</setting>
+
+	<setting propertyKey="@Properties.tz1_name" title="@Strings.tz1_name">
+		<settingConfig type="alphanumeric" maxLength="3" />
+	</setting>
+
+	<setting propertyKey="@Properties.tz1_dst" title="@Strings.tz1_dst">
+		<settingConfig type="boolean" />
+	</setting>
+
+	<setting propertyKey="@Properties.tz2_offset" title="@Strings.tz2_offset">
+		<settingConfig type="list">
+			<listEntry value="-12">@Strings.minus_twelve</listEntry>
+			<listEntry value="-11">@Strings.minus_eleven</listEntry>
+			<listEntry value="-10">@Strings.minus_ten</listEntry>
+			<listEntry value="-9">@Strings.minus_nine</listEntry>
+			<listEntry value="-8">@Strings.minus_eight</listEntry>
+			<listEntry value="-7">@Strings.minus_seven</listEntry>
+			<listEntry value="-6">@Strings.minus_six</listEntry>
+			<listEntry value="-5">@Strings.minus_five</listEntry>
+			<listEntry value="-4">@Strings.minus_four</listEntry>
+			<listEntry value="-3">@Strings.minus_three</listEntry>
+			<listEntry value="-2">@Strings.minus_two</listEntry>
+			<listEntry value="-1">@Strings.minus_one</listEntry>
+			<listEntry value="0">@Strings.zero</listEntry>
+			<listEntry value="1">@Strings.plus_one</listEntry>
+			<listEntry value="2">@Strings.plus_two</listEntry>
+			<listEntry value="3">@Strings.plus_three</listEntry>
+			<listEntry value="4">@Strings.plus_four</listEntry>
+			<listEntry value="5">@Strings.plus_five</listEntry>
+			<listEntry value="6">@Strings.plus_six</listEntry>
+			<listEntry value="7">@Strings.plus_seven</listEntry>
+			<listEntry value="8">@Strings.plus_eight</listEntry>
+			<listEntry value="9">@Strings.plus_nine</listEntry>
+			<listEntry value="10">@Strings.plus_ten</listEntry>
+			<listEntry value="11">@Strings.plus_eleven</listEntry>
+			<listEntry value="12">@Strings.plus_twelve</listEntry>
+		</settingConfig>
+	</setting>
+
+	<setting propertyKey="@Properties.tz2_name" title="@Strings.tz2_name">
+		<settingConfig type="alphanumeric" maxLength="3" />
+	</setting>
+
+	<setting propertyKey="@Properties.tz2_dst" title="@Strings.tz2_dst">
+		<settingConfig type="boolean" />
+	</setting>
+
+	<setting propertyKey="@Properties.tz3_offset" title="@Strings.tz3_offset">
+		<settingConfig type="list">
+			<listEntry value="-12">@Strings.minus_twelve</listEntry>
+			<listEntry value="-11">@Strings.minus_eleven</listEntry>
+			<listEntry value="-10">@Strings.minus_ten</listEntry>
+			<listEntry value="-9">@Strings.minus_nine</listEntry>
+			<listEntry value="-8">@Strings.minus_eight</listEntry>
+			<listEntry value="-7">@Strings.minus_seven</listEntry>
+			<listEntry value="-6">@Strings.minus_six</listEntry>
+			<listEntry value="-5">@Strings.minus_five</listEntry>
+			<listEntry value="-4">@Strings.minus_four</listEntry>
+			<listEntry value="-3">@Strings.minus_three</listEntry>
+			<listEntry value="-2">@Strings.minus_two</listEntry>
+			<listEntry value="-1">@Strings.minus_one</listEntry>
+			<listEntry value="0">@Strings.zero</listEntry>
+			<listEntry value="1">@Strings.plus_one</listEntry>
+			<listEntry value="2">@Strings.plus_two</listEntry>
+			<listEntry value="3">@Strings.plus_three</listEntry>
+			<listEntry value="4">@Strings.plus_four</listEntry>
+			<listEntry value="5">@Strings.plus_five</listEntry>
+			<listEntry value="6">@Strings.plus_six</listEntry>
+			<listEntry value="7">@Strings.plus_seven</listEntry>
+			<listEntry value="8">@Strings.plus_eight</listEntry>
+			<listEntry value="9">@Strings.plus_nine</listEntry>
+			<listEntry value="10">@Strings.plus_ten</listEntry>
+			<listEntry value="11">@Strings.plus_eleven</listEntry>
+			<listEntry value="12">@Strings.plus_twelve</listEntry>
+		</settingConfig>
+	</setting>
+
+	<setting propertyKey="@Properties.tz3_name" title="@Strings.tz3_name">
+		<settingConfig type="alphanumeric" maxLength="3" />
+	</setting>
+
+	<setting propertyKey="@Properties.tz3_dst" title="@Strings.tz3_dst">
+		<settingConfig type="boolean" />
+	</setting>
+	
+	<setting propertyKey="@Properties.tz4_offset" title="@Strings.tz4_offset">
+		<settingConfig type="list">
+			<listEntry value="-12">@Strings.minus_twelve</listEntry>
+			<listEntry value="-11">@Strings.minus_eleven</listEntry>
+			<listEntry value="-10">@Strings.minus_ten</listEntry>
+			<listEntry value="-9">@Strings.minus_nine</listEntry>
+			<listEntry value="-8">@Strings.minus_eight</listEntry>
+			<listEntry value="-7">@Strings.minus_seven</listEntry>
+			<listEntry value="-6">@Strings.minus_six</listEntry>
+			<listEntry value="-5">@Strings.minus_five</listEntry>
+			<listEntry value="-4">@Strings.minus_four</listEntry>
+			<listEntry value="-3">@Strings.minus_three</listEntry>
+			<listEntry value="-2">@Strings.minus_two</listEntry>
+			<listEntry value="-1">@Strings.minus_one</listEntry>
+			<listEntry value="0">@Strings.zero</listEntry>
+			<listEntry value="1">@Strings.plus_one</listEntry>
+			<listEntry value="2">@Strings.plus_two</listEntry>
+			<listEntry value="3">@Strings.plus_three</listEntry>
+			<listEntry value="4">@Strings.plus_four</listEntry>
+			<listEntry value="5">@Strings.plus_five</listEntry>
+			<listEntry value="6">@Strings.plus_six</listEntry>
+			<listEntry value="7">@Strings.plus_seven</listEntry>
+			<listEntry value="8">@Strings.plus_eight</listEntry>
+			<listEntry value="9">@Strings.plus_nine</listEntry>
+			<listEntry value="10">@Strings.plus_ten</listEntry>
+			<listEntry value="11">@Strings.plus_eleven</listEntry>
+			<listEntry value="12">@Strings.plus_twelve</listEntry>
+		</settingConfig>
+	</setting>
+	
+	<setting propertyKey="@Properties.tz4_name" title="@Strings.tz4_name">
+		<settingConfig type="alphanumeric" maxLength="3" />
+	</setting>
+		
+	<setting propertyKey="@Properties.tz4_dst" title="@Strings.tz4_dst">
+		<settingConfig type="boolean" />
+	</setting>
+
+</settings>

--- a/resources/layouts/layout.xml
+++ b/resources/layouts/layout.xml
@@ -1,65 +1,139 @@
-<layout id="WatchFace">
-	<drawable class="Background" />
+<resources>
+	<layout id="WatchFace">
+		<drawable class="Background" />
 
-	<drawable id="LeftGoalMeter" class="GoalMeter">
-		<param name="side">:left</param>
-		<param name="shape">:arc</param>
-		<param name="stroke">8</param>
-		<param name="height">160</param>
-		<param name="separator">2</param>
-	</drawable>
+		<drawable id="LeftGoalMeter" class="GoalMeter">
+			<param name="side">:left</param>
+			<param name="shape">:arc</param>
+			<param name="stroke">8</param>
+			<param name="height">160</param>
+			<param name="separator">2</param>
+		</drawable>
 
-	<drawable id="RightGoalMeter" class="GoalMeter">
-		<param name="side">:right</param>
-		<param name="shape">:arc</param>
-		<param name="stroke">8</param>
-		<param name="height">160</param>
-		<param name="separator">2</param>
-	</drawable>
+		<drawable id="RightGoalMeter" class="GoalMeter">
+			<param name="side">:right</param>
+			<param name="shape">:arc</param>
+			<param name="stroke">8</param>
+			<param name="height">160</param>
+			<param name="separator">2</param>
+		</drawable>
 
-	<label id="LeftGoalIcon" text="0" x="49" y="188" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_LEFT"/>
-	<label id="LeftGoalCurrent" text="3500" x="76" y="192" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
-	<label id="LeftGoalMax" text="5000" x="76" y="208" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="LeftGoalIcon" text="0" x="49" y="188" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_LEFT"/>
+		<label id="LeftGoalCurrent" text="3500" x="76" y="192" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="LeftGoalMax" text="5000" x="76" y="208" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
 
-	<label id="RightGoalIcon" text="1" x="191" y="188" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_RIGHT"/>
-	<label id="RightGoalCurrent" text="6" x="164" y="192" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
-	<label id="RightGoalMax" text="10" x="164" y="208" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="RightGoalIcon" text="1" x="191" y="188" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_RIGHT"/>
+		<label id="RightGoalCurrent" text="6" x="164" y="192" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="RightGoalMax" text="10" x="164" y="208" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
 
-	<drawable id="DataFields" class="DataFields">
-		<param name="left">80</param>
-		<param name="right">160</param>
-		<param name="top">24</param>
-		<param name="bottom">45</param>
-		<param name="batteryWidth">28</param>
-		<param name="batteryHeight">14</param>
-	</drawable>
+		<drawable id="DataFields" class="DataFields">
+			<param name="left">80</param>
+			<param name="right">160</param>
+			<param name="top">24</param>
+			<param name="bottom">45</param>
+			<param name="batteryWidth">28</param>
+			<param name="batteryHeight">14</param>
+		</drawable>
 
-	<drawable id="Date" class="DateLine">
-		<param name="y">74</param>
-	</drawable>
+		<drawable id="Date" class="DateLine">
+			<param name="y">74</param>
+		</drawable>
 
-	<drawable id="Indicators" class="Indicators">
-		<param name="locX">31</param>
-		<param name="locY">120</param>
-		<param name="spacingY">30</param>
-		<param name="batteryWidth">24</param>
-		<param name="batteryHeight">12</param>
-	</drawable>
+		<drawable id="Indicators" class="Indicators">
+			<param name="locX">31</param>
+			<param name="locY">120</param>
+			<param name="spacingY">30</param>
+			<param name="batteryWidth">24</param>
+			<param name="batteryHeight">12</param>
+		</drawable>
 
-	<drawable id="Time" class="ThickThinTime">
-		<param name="secondsX">163</param>
-		<param name="secondsY">142</param>
-		<param name="secondsClipY">154</param>
-		<param name="secondsClipWidth">26</param>
-		<param name="secondsClipHeight">17</param>
-	</drawable>
+		<drawable id="Time" class="ThickThinTime">
+			<param name="ampmY">120</param>
+			<param name="secondsX">163</param>
+			<param name="secondsY">142</param>
+			<param name="secondsClipY">154</param>
+			<param name="secondsClipWidth">26</param>
+			<param name="secondsClipHeight">17</param>
+		</drawable>
 
-	<drawable id="MoveBar" class="MoveBar">
-		<param name="x">52</param>
-		<param name="y">161</param>
-		<param name="width">105</param>
-		<param name="height">9</param>
-		<param name="separator">3</param>
-	</drawable>
+		<drawable id="MoveBar" class="MoveBar">
+			<param name="x">52</param>
+			<param name="y">161</param>
+			<param name="width">105</param>
+			<param name="height">9</param>
+			<param name="separator">3</param>
+		</drawable>
 	
-</layout>
+	</layout>
+	<layout id="WatchFaceTZ">
+		<drawable class="Background" />
+
+		<drawable id="LeftGoalMeter" class="GoalMeter">
+			<param name="side">:left</param>
+			<param name="shape">:arc</param>
+			<param name="stroke">8</param>
+			<param name="height">160</param>
+			<param name="separator">2</param>
+		</drawable>
+
+		<drawable id="RightGoalMeter" class="GoalMeter">
+			<param name="side">:right</param>
+			<param name="shape">:arc</param>
+			<param name="stroke">8</param>
+			<param name="height">160</param>
+			<param name="separator">2</param>
+		</drawable>
+
+		<label id="LeftGoalIcon" text="0" x="49" y="188" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_LEFT"/>
+		<label id="LeftGoalCurrent" text="3500" x="76" y="192" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="LeftGoalMax" text="5000" x="76" y="208" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_LEFT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+
+		<label id="RightGoalIcon" text="1" x="191" y="188" font="@Fonts.IconsFont" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_RIGHT"/>
+		<label id="RightGoalCurrent" text="6" x="164" y="192" font="@Fonts.NormalFont" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+		<label id="RightGoalMax" text="10" x="164" y="208" font="@Fonts.NormalFont" color="Gfx.COLOR_LT_GRAY" justification="Gfx.TEXT_JUSTIFY_RIGHT | Gfx.TEXT_JUSTIFY_VCENTER"/>
+
+		<drawable id="DataFields" class="DataFields">
+			<param name="left">80</param>
+			<param name="right">160</param>
+			<param name="top">24</param>
+			<param name="bottom">45</param>
+			<param name="batteryWidth">28</param>
+			<param name="batteryHeight">14</param>
+		</drawable>
+
+		<drawable id="Date" class="DateLine">
+			<param name="y">65</param>
+		</drawable>
+
+		<drawable id="Indicators" class="Indicators">
+			<param name="locX">31</param>
+			<param name="locY">120</param>
+			<param name="spacingY">30</param>
+			<param name="batteryWidth">24</param>
+			<param name="batteryHeight">12</param>
+		</drawable>
+
+		<drawable id="Time" class="ThickThinTime">
+			<param name="ampmY">110</param>
+			<param name="secondsX">0</param>
+			<param name="secondsY">115</param>
+			<param name="secondsClipY">125</param>
+			<param name="secondsClipWidth">30</param>
+			<param name="secondsClipHeight">22</param>
+		</drawable>
+		
+		<drawable id="Timezones" class="Timezones">
+			<param name="topY">86</param>
+			<param name="bottomY">156</param>
+		</drawable>
+
+		<drawable id="MoveBar" class="MoveBar">
+			<param name="x">60</param>
+			<param name="y">175</param>
+			<param name="width">120</param>
+			<param name="height">9</param>
+			<param name="separator">3</param>
+		</drawable>
+		
+	</layout>
+</resources>	

--- a/resources/settings/properties.xml
+++ b/resources/settings/properties.xml
@@ -1,6 +1,6 @@
 <properties>
 
-	<property id="AppVersion" type="string">1.8.0</property>
+	<property id="AppVersion" type="string">1.9.0</property>
 
 	<property id="Theme" type="number">0</property>
 
@@ -34,5 +34,7 @@
 	
 	<property id="HideSeconds" type="boolean">false</property>
 	<property id="HideHoursLeadingZero" type="boolean">false</property>
+
+	<property id="timezones" type="number">0</property>
 
 </properties>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -93,4 +93,54 @@
 	<string id="Nov">Nov</string>
 	<string id="Dec">Dec</string>
 
+	<string id="timezones">Timezones</string>
+	<string id="tz1_offset">Timezone 1 Offset</string>
+	<string id="tz1_name">Timezone 1 Name</string>
+	<string id="tz1_dst">Timezone 1 Summer Time (DST)</string>
+	<string id="tz2_offset">Timezone 2 Offset</string>
+	<string id="tz2_name">Timezone 2 Name</string>
+	<string id="tz2_dst">Timezone 2 Summer Time (DST)</string>
+	<string id="tz3_offset">Timezone 3 Offset</string>
+	<string id="tz3_name">Timezone 3 Name</string>
+	<string id="tz3_dst">Timezone 3 Summer Time (DST)</string>
+	<string id="tz4_offset">Timezone 4 Offset</string>
+	<string id="tz4_name">Timezone 4 Name</string>
+	<string id="tz4_dst">Timezone 4 Summer Time (DST)</string>
+	<string id="tz5_offset">Timezone 5 Offset</string>
+	<string id="tz5_name">Timezone 5 Name</string>
+	<string id="tz5_dst">Timezone 5 Summer Time (DST)</string>
+	<string id="tz6_offset">Timezone 6 Offset</string>
+	<string id="tz6_name">Timezone 6 Name</string>
+	<string id="tz6_dst">Timezone 6 Summer Time (DST)</string>
+
+	<string id="plus_twelve">+12</string>
+	<string id="plus_eleven">+11</string>
+	<string id="plus_ten">+10</string>
+	<string id="plus_nine">+9</string>
+	<string id="plus_eight">+8</string>
+	<string id="plus_seven">+7</string>
+	<string id="plus_six">+6</string>
+	<string id="plus_five">+5</string>
+	<string id="plus_four">+4</string>
+	<string id="plus_three">+3</string>
+	<string id="plus_two">+2</string>
+	<string id="plus_one">+1</string>
+	<string id="minus_twelve">-12</string>
+	<string id="minus_eleven">-11</string>
+	<string id="minus_ten">-10</string>
+	<string id="minus_nine">-9</string>
+	<string id="minus_eight">-8</string>
+	<string id="minus_seven">-7</string>
+	<string id="minus_six">-6</string>
+	<string id="minus_five">-5</string>
+	<string id="minus_four">-4</string>
+	<string id="minus_three">-3</string>
+	<string id="minus_two">-2</string>
+	<string id="minus_one">-1</string>
+	<string id="zero">0</string>
+
+	<string id="two">2</string>
+	<string id="four">4</string>
+	<string id="six">6</string>
+
 </strings>


### PR DESCRIPTION
I work with teams around the world and built my own watchface which allows 2 or 4 timezones to be shown in addition to the local time. This is available on the Garmin App Store: https://apps.garmin.com/en-US/apps/ebf9bf84-cbe7-46e4-8752-85cb8e5a59da

It  is a very basic watchface, but myself and some of my colleagues use it. I started getting requests from some of my colleagues for additional functionality such as heartrate, so rather than reinvent the wheel I have merged my multi-timezone code with your code. 

I have learnt a huge amount doing this. 

Some caveats, I have this working for the round and semi-round watchfaces, but not the rectangular watch faces. It also doesn't work on the FR735 due to lack of memory. I also only have the additional strings in English. 

If you select 0 timezones, it will look exactly like the original, but if you select 2 or 4 timezones it will switch the layout to fit the timezones in. If it is a watch where I haven't added support, the timezone options will not appear in the settings. 

Please consider this pull request, I would love to have this functionality in Crystal Watchface. 

I have attached a screenshot of how this looks with 4 timezones. 
![crystalapp-vivoactive3](https://user-images.githubusercontent.com/1262895/42738888-ae305910-8859-11e8-9478-09d410619852.png)
