### PR TITLE
Add meters climbed data field

### DIFF
--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -76,6 +76,7 @@
 			<listEntry value="10">@Strings.SunriseSunset</listEntry>
 			<listEntry value="11">@Strings.Weather</listEntry>
 			<listEntry value="13">@Strings.Humidity</listEntry>
+			<listEntry value="14">@Strings.MetersClimbed</listEntry>
 		</settingConfig>
 	</setting>
 
@@ -95,6 +96,7 @@
 			<listEntry value="10">@Strings.SunriseSunset</listEntry>
 			<listEntry value="11">@Strings.Weather</listEntry>
 			<listEntry value="13">@Strings.Humidity</listEntry>
+			<listEntry value="14">@Strings.MetersClimbed</listEntry>
 		</settingConfig>
 	</setting>
 
@@ -114,6 +116,7 @@
 			<listEntry value="10">@Strings.SunriseSunset</listEntry>
 			<listEntry value="11">@Strings.Weather</listEntry>
 			<listEntry value="13">@Strings.Humidity</listEntry>
+			<listEntry value="14">@Strings.MetersClimbed</listEntry>
 		</settingConfig>
 	</setting>
 

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -72,6 +72,7 @@
 	<string id="Weather">Weather</string>
 	<string id="Humidity">Humidity</string>
 	<string id="Pressure">Pressure</string>
+	<string id="MetersClimbed">Meters climbed</string>
 
 	<!-- Internal use only. Required because fonts cannot be overridden by locale. Leave blank for no override. -->
 	<string id="DATE_FONT_OVERRIDE"></string>


### PR DESCRIPTION
I'm pretty new to writing anything for garmin devices, so I didn't quite got this running as a test, perhaps you could include some documentation in a `CONTRIBUTING.md` file on how to help out.
I love the watch face and have some ideas for new features.

Meters climbed / total elevation would be an amazing indicator alongside a distance display, especially if doing a lot of hiking in the mountains and not necessarily tracking such activities, you'd still get a good picture of how you were doing that day.

That being said, as far as I know the value provided won't take elevation gain from cycling into account. 
For such cases something like pinging `Sensor.Info.altitude` every other minute (perhaps make this configurable via an "accuracy" setting) and accumulating gained meters might be more accurate but probably also a lot more draining on the battery, so for now I'd stick to the data provided by garmin.

The new setting `Meters climbed` uses the same icon as for altitude, as I think it's quite an appropriate choice.