### PR TITLE
Add Option to Have Battery Indicator Numerically

### DIFF
--- a/resources-deu/strings/strings.xml
+++ b/resources-deu/strings/strings.xml
@@ -63,6 +63,7 @@
 	<string id="HeartRate">Herzfrequenz</string>
 	<string id="HeartRateLive5s">Herzfrequenz (Live 5s)</string>
 	<string id="Battery">Batterie</string>
+	<string id="BatteryNumeric">Batterie Numerisch</string>
 	<string id="BatteryHidePercentage">Batterie (Prozente ausgeblendet)</string>
 	<string id="Notifications">Hinweise</string>
 	<string id="Calories">Kalorien</string>

--- a/resources-dut/strings/strings.xml
+++ b/resources-dut/strings/strings.xml
@@ -63,6 +63,7 @@
 	<string id="HeartRate">Heart Rate</string>
 	<string id="HeartRateLive5s">Heart Rate (Live 5s)</string>
 	<string id="Battery">Battery</string>
+	<string id="BatteryNumeric">Battery Numeric</string>
 	<string id="BatteryHidePercentage">Battery (Hide Percentage)</string>
 	<string id="Notifications">Notifications</string>
 	<string id="Calories">Calories</string>

--- a/resources-fin/strings/strings.xml
+++ b/resources-fin/strings/strings.xml
@@ -63,6 +63,7 @@
 	<string id="HeartRate">Heart Rate</string>
 	<string id="HeartRateLive5s">Heart Rate (Live 5s)</string>
 	<string id="Battery">Battery</string>
+	<string id="BatteryNumeric">Battery Numeric</string>
 	<string id="BatteryHidePercentage">Battery (Hide Percentage)</string>
 	<string id="Notifications">Notifications</string>
 	<string id="Calories">Calories</string>

--- a/resources-fre/strings/strings.xml
+++ b/resources-fre/strings/strings.xml
@@ -63,6 +63,7 @@
 	<string id="HeartRate">Heart Rate</string>
 	<string id="HeartRateLive5s">Heart Rate (Live 5s)</string>
 	<string id="Battery">Battery</string>
+	<string id="BatteryNumeric">Battery Numeric</string>
 	<string id="BatteryHidePercentage">Battery (Hide Percentage)</string>
 	<string id="Notifications">Notifications</string>
 	<string id="Calories">Calories</string>

--- a/resources-hrv/strings/strings.xml
+++ b/resources-hrv/strings/strings.xml
@@ -63,6 +63,7 @@
 	<string id="HeartRate">Heart Rate</string>
 	<string id="HeartRateLive5s">Heart Rate (Live 5s)</string>
 	<string id="Battery">Battery</string>
+	<string id="BatteryNumeric">Battery Numeric</string>
 	<string id="BatteryHidePercentage">Battery (Hide Percentage)</string>
 	<string id="Notifications">Notifications</string>
 	<string id="Calories">Calories</string>

--- a/resources-hun/strings/strings.xml
+++ b/resources-hun/strings/strings.xml
@@ -63,6 +63,7 @@
 	<string id="HeartRate">Heart Rate</string>
 	<string id="HeartRateLive5s">Heart Rate (Live 5s)</string>
 	<string id="Battery">Battery</string>
+	<string id="BatteryNumeric">Battery Numeric</string>
 	<string id="BatteryHidePercentage">Battery (Hide Percentage)</string>
 	<string id="Notifications">Notifications</string>
 	<string id="Calories">Calories</string>

--- a/resources-ita/strings/strings.xml
+++ b/resources-ita/strings/strings.xml
@@ -63,6 +63,7 @@
 	<string id="HeartRate">Heart Rate</string>
 	<string id="HeartRateLive5s">Heart Rate (Live 5s)</string>
 	<string id="Battery">Battery</string>
+	<string id="BatteryNumeric">Battery Numeric</string>
 	<string id="BatteryHidePercentage">Battery (Hide Percentage)</string>
 	<string id="Notifications">Notifications</string>
 	<string id="Calories">Calories</string>

--- a/resources-nob/strings/strings.xml
+++ b/resources-nob/strings/strings.xml
@@ -63,6 +63,7 @@
 	<string id="HeartRate">Heart Rate</string>
 	<string id="HeartRateLive5s">Heart Rate (Live 5s)</string>
 	<string id="Battery">Battery</string>
+	<string id="BatteryNumeric">Battery Numeric</string>
 	<string id="BatteryHidePercentage">Battery (Hide Percentage)</string>
 	<string id="Notifications">Notifications</string>
 	<string id="Calories">Calories</string>

--- a/resources-pol/strings/strings.xml
+++ b/resources-pol/strings/strings.xml
@@ -63,6 +63,7 @@
 	<string id="HeartRate">Tętno</string>
 	<string id="HeartRateLive5s">Tętno (Live 5s)</string>
 	<string id="Battery">Bateria</string>
+	<string id="BatteryNumeric">Bateria Numeric</string>
 	<string id="BatteryHidePercentage">Bateria (Sama Wartość)</string>
 	<string id="Notifications">Powiadomienia</string>
 	<string id="Calories">Kalorie</string>

--- a/resources-por/strings/strings.xml
+++ b/resources-por/strings/strings.xml
@@ -63,6 +63,7 @@
 	<string id="HeartRate">Heart Rate</string>
 	<string id="HeartRateLive5s">Heart Rate (Live 5s)</string>
 	<string id="Battery">Battery</string>
+	<string id="BatteryNumeric">Battery Numeric</string>
 	<string id="BatteryHidePercentage">Battery (Hide Percentage)</string>
 	<string id="Notifications">Notifications</string>
 	<string id="Calories">Calories</string>

--- a/resources-rus/strings/strings.xml
+++ b/resources-rus/strings/strings.xml
@@ -63,6 +63,7 @@
 	<string id="HeartRate">Пульс</string>
 	<string id="HeartRateLive5s">Пульс (обновлять каждые 5сек)</string>
 	<string id="Battery">Заряд аккумулятора</string>
+	<string id="BatteryNumeric">Заряд аккумулятора Цифровой дисплей</string>
 	<string id="BatteryHidePercentage">Заряд аккумулятора (скрывать проценты)</string>
 	<string id="Notifications">Уведомления</string>
 	<string id="Calories">Калории</string>

--- a/resources-slo/strings/strings.xml
+++ b/resources-slo/strings/strings.xml
@@ -63,6 +63,7 @@
 	<string id="HeartRate">Heart Rate</string>
 	<string id="HeartRateLive5s">Heart Rate (Live 5s)</string>
 	<string id="Battery">Battery</string>
+	<string id="BatteryNumeric">Battery Numeric</string>
 	<string id="BatteryHidePercentage">Battery (Hide Percentage)</string>
 	<string id="Notifications">Notifications</string>
 	<string id="Calories">Calories</string>

--- a/resources-slv/strings/strings.xml
+++ b/resources-slv/strings/strings.xml
@@ -63,6 +63,7 @@
 	<string id="HeartRate">Heart Rate</string>
 	<string id="HeartRateLive5s">Heart Rate (Live 5s)</string>
 	<string id="Battery">Battery</string>
+	<string id="BatteryNumeric">Battery Numeric</string>
 	<string id="BatteryHidePercentage">Battery (Hide Percentage)</string>
 	<string id="Notifications">Notifications</string>
 	<string id="Calories">Calories</string>

--- a/resources-spa/strings/strings.xml
+++ b/resources-spa/strings/strings.xml
@@ -63,6 +63,7 @@
 	<string id="HeartRate">Heart Rate</string>
 	<string id="HeartRateLive5s">Heart Rate (Live 5s)</string>
 	<string id="Battery">Battery</string>
+	<string id="BatteryNumeric">Battery Numeric</string>
 	<string id="BatteryHidePercentage">Battery (Hide Percentage)</string>
 	<string id="Notifications">Notifications</string>
 	<string id="Calories">Calories</string>

--- a/resources-swe/strings/strings.xml
+++ b/resources-swe/strings/strings.xml
@@ -63,6 +63,7 @@
 	<string id="HeartRate">Puls</string>
 	<string id="HeartRateLive5s">Puls (Live 5s)</string>
 	<string id="Battery">Batteri</string>
+	<string id="BatteryNumeric">Batteri Numeric</string>
 	<string id="BatteryHidePercentage">Batteri (Dölj procent)</string>
 	<string id="Notifications">Notifieringar</string>
 	<string id="Calories">Kalorier</string>

--- a/resources-zhs/strings/strings.xml
+++ b/resources-zhs/strings/strings.xml
@@ -63,6 +63,7 @@
 	<string id="HeartRate">Heart Rate</string>
 	<string id="HeartRateLive5s">Heart Rate (Live 5s)</string>
 	<string id="Battery">Battery</string>
+	<string id="BatteryNumeric">Battery Numeric</string>
 	<string id="BatteryHidePercentage">Battery (Hide Percentage)</string>
 	<string id="Notifications">Notifications</string>
 	<string id="Calories">Calories</string>

--- a/resources-zht/strings/strings.xml
+++ b/resources-zht/strings/strings.xml
@@ -63,6 +63,7 @@
 	<string id="HeartRate">Heart Rate</string>
 	<string id="HeartRateLive5s">Heart Rate (Live 5s)</string>
 	<string id="Battery">Battery</string>
+	<string id="BatteryNumeric">Battery Numeric</string>
 	<string id="BatteryHidePercentage">Battery (Hide Percentage)</string>
 	<string id="Notifications">Notifications</string>
 	<string id="Calories">Calories</string>

--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -140,6 +140,7 @@
 			<listEntry value="2">@Strings.Notifications</listEntry>
 			<listEntry value="3">@Strings.BluetoothOrNotifications</listEntry>
 			<listEntry value="4">@Strings.Battery</listEntry>
+			<listEntry value="5">@Strings.BatteryNumeric</listEntry>
 		</settingConfig>
 	</setting>
 
@@ -150,6 +151,7 @@
 			<listEntry value="2">@Strings.Notifications</listEntry>
 			<listEntry value="3">@Strings.BluetoothOrNotifications</listEntry>
 			<listEntry value="4">@Strings.Battery</listEntry>
+			<listEntry value="5">@Strings.BatteryNumeric</listEntry>
 		</settingConfig>
 	</setting>
 
@@ -160,6 +162,7 @@
 			<listEntry value="2">@Strings.Notifications</listEntry>
 			<listEntry value="3">@Strings.BluetoothOrNotifications</listEntry>
 			<listEntry value="4">@Strings.Battery</listEntry>
+			<listEntry value="5">@Strings.BatteryNumeric</listEntry>
 		</settingConfig>
 	</setting>
 

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -63,6 +63,7 @@
 	<string id="HeartRate">Heart Rate</string>
 	<string id="HeartRateLive5s">Heart Rate (Live 5s)</string>
 	<string id="Battery">Battery</string>
+	<string id="BatteryNumeric">Battery Numeric</string>
 	<string id="BatteryHidePercentage">Battery (Hide Percentage)</string>
 	<string id="Notifications">Notifications</string>
 	<string id="Calories">Calories</string>

--- a/source/CrystalView.mc
+++ b/source/CrystalView.mc
@@ -76,6 +76,12 @@ function drawBatteryMeter(dc, x, y, width, height) {
 		height - (2 * lineWidthPlusMargin));
 }
 
+
+function writeBatteryLevel(dc, x, y, width, height) {
+	dc.setColor(gThemeColour, Graphics.COLOR_TRANSPARENT);
+	dc.drawText(x - (width / 2), y - height, gNormalFont, Math.floor(Sys.getSystemStats().battery).format(INTEGER_FORMAT) + "%", Graphics.TEXT_JUSTIFY_LEFT);
+}
+
 class CrystalView extends Ui.WatchFace {
 	private var mIsSleeping = false;
 	private var mIsBurnInProtection = false; // Is burn-in protection required and active?

--- a/source/Indicators.mc
+++ b/source/Indicators.mc
@@ -93,6 +93,11 @@ class Indicators extends Ui.Drawable {
 			return;
 		}
 
+		if (indicatorType == 5 /* INDICATOR_TYPE_BATTERY_NUMERIC */) {
+			writeBatteryLevel(dc, x, y, mBatteryWidth, mBatteryWidth / 2);
+			return;
+		}
+
 		// Show notifications icon if connected and there are notifications, bluetoothicon otherwise.
 		var settings = Sys.getDeviceSettings();
 		if (indicatorType == 3 /* INDICATOR_TYPE_BLUETOOTH_OR_NOTIFICATIONS */) {


### PR DESCRIPTION
Hi,
with this merged, there will be an additional option for the indicator types which actually shows the percentage of the battery charge instead of the iconic representation of a battery progress bar.

Thank you for all your effort anyways. This is a very nice watch face.