### PR TITLE
Fixed typo in Dutch translation

### DIFF
--- a/resources-dut/strings/strings.xml
+++ b/resources-dut/strings/strings.xml
@@ -75,7 +75,7 @@
 	<string id="Bluetooth">Bluetooth</string>
 	<string id="BluetoothOrNotifications">Bluetooth/Notificaties</string>
 	<string id="SunriseSunset">Zonopkomst / -Ondergang</string>
-	<string id="Weather">Weeer</string>
+	<string id="Weather">Weer</string>
 	<string id="Humidity">Vochtigheid</string>
 	<string id="Pressure">Luchtdruk</string>
 


### PR DESCRIPTION
Fixed typo in Weeer to Weer (translation of the word Weather).

By the way, I love your watch face. It's the clearest and best so far. Great work.