### PR TITLE
Move seconds after minutes

### DIFF
--- a/always-on-source/AlwaysOnDisplay.mc
+++ b/always-on-source/AlwaysOnDisplay.mc
@@ -22,7 +22,7 @@ class AlwaysOnDisplay extends Ui.Drawable {
 	private var mDataY;
 	private var mDataLeft;
 
-	private var AM_PM_X_OFFSET = 2;
+	private var mAmPmOffsetX = 2;
 
 	private var mDayOfWeek;
 	private var mDayOfWeekString;
@@ -39,8 +39,8 @@ class AlwaysOnDisplay extends Ui.Drawable {
 			mAdjustY = params[:adjustY];
 		}
 
-		if (params[:amPmOffset] != null) {
-			AM_PM_X_OFFSET = params[:amPmOffset];
+		if (params[:amPmOffsetX] != null) {
+			mAmPmOffsetX = params[:amPmOffsetX];
 		}
 
 		mTimeY = params[:timeY];
@@ -118,7 +118,7 @@ class AlwaysOnDisplay extends Ui.Drawable {
 		if (amPmText.length() > 0) {
 			x += dc.getTextWidthInPixels(minutes, mMinutesFont);
 			dc.drawText(
-				x + AM_PM_X_OFFSET, // Breathing space between minutes and AM/PM.
+				x + mAmPmOffsetX, // Breathing space between minutes and AM/PM.
 				y,
 				mSecondsFont,
 				amPmText,

--- a/resources-rectangle-148x205/layouts/layout.xml
+++ b/resources-rectangle-148x205/layouts/layout.xml
@@ -45,25 +45,28 @@
 	</drawable>
 
 	<drawable id="Time" class="ThickThinTime">
-		<param name="secondsX">105</param>
-		<param name="secondsY">113</param>
+		<param name="secondsX">122</param>
+		<param name="secondsY">91</param>
 
 		<!-- Partial updates not supported -->	
 		<!-- param name="secondsClipY">122</param-->
 		<!-- param name="secondsClipWidth">22</param-->
 		<!-- param name="secondsClipHeight">15</param-->
 
+		<!-- Move time up slightly to left within available space -->
+		<param name="adjustX">-8</param>
 		<!-- Move time up slightly to centre vertically within available space -->
 		<param name="adjustY">-6</param>
 
 		<!-- Limited horizontal space, so reduce AM/PM offset -->
-		<param name="amPmOffset">0</param>
+		<param name="amPmOffsetX">0</param>
+		<param name="amPmOffsetY">5</param>
 	</drawable>
 
 	<drawable id="MoveBar" class="MoveBar">
 		<param name="x">23</param>
 		<param name="y">130</param>
-		<param name="width">75</param>
+		<param name="width">105</param>
 		<param name="height">7</param>
 		<param name="separator">3</param>
 	</drawable>

--- a/resources-rectangle-205x148/layouts/layout.xml
+++ b/resources-rectangle-205x148/layouts/layout.xml
@@ -47,8 +47,8 @@
 	</drawable>
 
 	<drawable id="Time" class="ThickThinTime">
-		<param name="secondsX">137</param>
-		<param name="secondsY">85</param>
+		<param name="secondsX">166</param>
+		<param name="secondsY">64</param>
 
 		<!-- Partial updates not supported -->	
 		<!-- param name="secondsClipY">124</param-->
@@ -59,13 +59,14 @@
 		<param name="adjustY">-5</param>
 
 		<!-- Ample horizontal space, so increase AM/PM offset -->
-		<param name="amPmOffset">4</param>
+		<param name="amPmOffsetX">4</param>
+		<param name="amPmOffsetY">4</param>
 	</drawable>
 
 	<drawable id="MoveBar" class="MoveBar">
 		<param name="x">45</param>
 		<param name="y">102</param>
-		<param name="width">87</param>
+		<param name="width">120</param>
 		<param name="height">7</param>
 		<param name="separator">3</param>
 	</drawable>

--- a/resources-rectangle-240x240/layouts/layout.xml
+++ b/resources-rectangle-240x240/layouts/layout.xml
@@ -47,15 +47,16 @@
 
 		<drawable id="Time" class="ThickThinTime">
 			<param name="adjustY">2</param>
-			<param name="secondsX">172</param>
-			<param name="secondsY">155</param>
-			<param name="amPmOffset">6</param>
+			<param name="secondsX">205</param>
+			<param name="secondsY">121</param>
+			<param name="amPmOffsetX">2</param>
+			<param name="amPmOffsetY">5</param>
 		</drawable>
 
 		<drawable id="MoveBar" class="MoveBar">
 			<param name="x">40</param>
 			<param name="y">176</param>
-			<param name="width">123</param>
+			<param name="width">166</param>
 			<param name="height">11</param>
 			<param name="separator">3</param>
 		</drawable>
@@ -69,7 +70,7 @@
 			<param name="timeY">102</param>
 			<param name="lineY">133</param>
 			<!-- Allow room for Chinese date -->	
-			<param name="lineWidth">162</param>
+			<param name="lineWidth">192</param>
 			<!-- param name="lineStroke">2</param -->	
 			<param name="dataY">150</param>
 			<param name="dataLeft">49</param>

--- a/resources-round-208x208/layouts/layout.xml
+++ b/resources-round-208x208/layouts/layout.xml
@@ -50,19 +50,20 @@
 	</drawable>
 
 	<drawable id="Time" class="ThickThinTime">
-		<param name="secondsX">144</param>
-		<param name="secondsY">126</param>
+		<param name="secondsX">170</param>
+		<param name="secondsY">100</param>
 
 		<!-- Partial updates not supported -->		
 		<!--param name="secondsClipY">139</param-->
 		<!--param name="secondsClipWidth">22</param-->
 		<!--param name="secondsClipHeight">15</param-->
+		<param name="amPmOffsetY">1</param>
 	</drawable>
 
 	<drawable id="MoveBar" class="MoveBar">
 		<param name="x">44</param>
 		<param name="y">143</param>
-		<param name="width">94</param>
+		<param name="width">124</param>
 		<param name="height">9</param>
 		<param name="separator">3</param>
 	</drawable>

--- a/resources-round-218x218-ciq_1.x/layouts/layout.xml
+++ b/resources-round-218x218-ciq_1.x/layouts/layout.xml
@@ -50,19 +50,20 @@
 	</drawable>
 
 	<drawable id="Time" class="ThickThinTime">
-		<param name="secondsX">149</param>
-		<param name="secondsY">129</param>
+		<param name="secondsX">176</param>
+		<param name="secondsY">106</param>		
 
 		<!-- Partial updates not supported -->	
 		<!--param name="secondsClipY">139</param-->
 		<!--param name="secondsClipWidth">22</param-->
 		<!--param name="secondsClipHeight">15</param-->
+		<param name="amPmOffsetY">1</param>
 	</drawable>
 
 	<drawable id="MoveBar" class="MoveBar">
 		<param name="x">49</param>
 		<param name="y">146</param>
-		<param name="width">94</param>
+		<param name="width">124</param>
 		<param name="height">9</param>
 		<param name="separator">3</param>
 	</drawable>

--- a/resources-round-218x218/layouts/layout.xml
+++ b/resources-round-218x218/layouts/layout.xml
@@ -45,17 +45,18 @@
 	</drawable>
 
 	<drawable id="Time" class="ThickThinTime">
-		<param name="secondsX">149</param>
-		<param name="secondsY">129</param>		
-		<param name="secondsClipY">139</param>
+		<param name="secondsX">176</param>
+		<param name="secondsY">106</param>		
+		<param name="secondsClipY">116</param>
 		<param name="secondsClipWidth">22</param>
 		<param name="secondsClipHeight">15</param>
+		<param name="amPmOffsetY">1</param>
 	</drawable>
 
 	<drawable id="MoveBar" class="MoveBar">
 		<param name="x">49</param>
 		<param name="y">146</param>
-		<param name="width">94</param>
+		<param name="width">124</param>
 		<param name="height">9</param>
 		<param name="separator">3</param>
 	</drawable>

--- a/resources-round-260x260/layouts/layout.xml
+++ b/resources-round-260x260/layouts/layout.xml
@@ -46,17 +46,18 @@
 
 	<drawable id="Time" class="ThickThinTime">
         <param name="adjustY">-5</param>
-		<param name="secondsX">182</param>
-		<param name="secondsY">158</param>
-		<param name="secondsClipY">170</param>
+		<param name="secondsX">216</param>
+		<param name="secondsY">124</param>
+		<param name="secondsClipY">136</param>
 		<param name="secondsClipWidth">29</param>
 		<param name="secondsClipHeight">19</param>
+		<param name="amPmOffsetY">5</param>
 	</drawable>
 
 	<drawable id="MoveBar" class="MoveBar">
 		<param name="x">52</param>
 		<param name="y">179</param>
-		<param name="width">123</param>
+		<param name="width">160</param>
 		<param name="height">11</param>
 		<param name="separator">3</param>
 	</drawable>

--- a/resources-round-280x280/layouts/layout.xml
+++ b/resources-round-280x280/layouts/layout.xml
@@ -46,17 +46,19 @@
 
 	<drawable id="Time" class="ThickThinTime">
         <param name="adjustY">-4</param>
-		<param name="secondsX">197</param>
-		<param name="secondsY">171</param>
-		<param name="secondsClipY">185</param>
+		<param name="secondsX">228</param>
+		<param name="secondsY">135</param>
+		<param name="secondsClipY">149</param>
 		<param name="secondsClipWidth">31</param>
 		<param name="secondsClipHeight">20</param>
+		<param name="amPmOffsetX">-4</param>
+		<param name="amPmOffsetY">4</param>
 	</drawable>
 
 	<drawable id="MoveBar" class="MoveBar">
 		<param name="x">55</param>
 		<param name="y">194</param>
-		<param name="width">133</param>
+		<param name="width">174</param>
 		<param name="height">11</param>
 		<param name="separator">3</param>
 	</drawable>

--- a/resources-round-360x360/layouts/layout.xml
+++ b/resources-round-360x360/layouts/layout.xml
@@ -47,14 +47,16 @@
 
 		<drawable id="Time" class="ThickThinTime">
 			<param name="adjustY">-4</param>
-			<param name="secondsX">256</param>
-			<param name="secondsY">218</param>
+			<param name="secondsX">294</param>
+			<param name="secondsY">175</param>
+			<param name="amPmOffsetX">-4</param>
+			<param name="amPmOffsetY">7</param>
 		</drawable>
 
 		<drawable id="MoveBar" class="MoveBar">
 			<param name="x">68</param>
 			<param name="y">248</param>
-			<param name="width">181</param>
+			<param name="width">228</param>
 			<param name="height">13</param>
 			<param name="separator">4</param>
 		</drawable>
@@ -68,8 +70,8 @@
 			<param name="adjustY">-4</param>
 			<param name="timeY">153</param>
 			<param name="lineY">198</param>
-			<!-- Allow room for Chinese date -->	
-			<param name="lineWidth">230</param>
+			<!-- Allow room for Chinese date -->
+			<param name="lineWidth">250</param>
 			<!-- param name="lineStroke">2</param -->	
 			<param name="dataY">223</param>
 			<param name="dataLeft">80</param>

--- a/resources-round-390x390/layouts/layout.xml
+++ b/resources-round-390x390/layouts/layout.xml
@@ -47,14 +47,16 @@
 
 		<drawable id="Time" class="ThickThinTime">
 			<param name="adjustY">-4</param>
-			<param name="secondsX">272</param>
-			<param name="secondsY">234</param>
+			<param name="secondsX">320</param>
+			<param name="secondsY">190</param>
+			<param name="amPmOffsetX">-2</param>
+			<param name="amPmOffsetY">7</param>
 		</drawable>
 
 		<drawable id="MoveBar" class="MoveBar">
 			<param name="x">77</param>
 			<param name="y">265</param>
-			<param name="width">180</param>
+			<param name="width">240</param>
 			<param name="height">13</param>
 			<param name="separator">4</param>
 		</drawable>
@@ -68,8 +70,8 @@
 			<param name="adjustY">-4</param>
 			<param name="timeY">169</param>
 			<param name="lineY">217</param>
-			<!-- Allow room for Chinese date -->	
-			<param name="lineWidth">230</param>
+			<!-- Allow room for Chinese date -->
+			<param name="lineWidth">280</param>
 			<!-- param name="lineStroke">2</param -->	
 			<param name="dataY">241</param>
 			<param name="dataLeft">95</param>

--- a/resources-round-416x416/layouts/layout.xml
+++ b/resources-round-416x416/layouts/layout.xml
@@ -47,14 +47,16 @@
 
 		<drawable id="Time" class="ThickThinTime">
 			<param name="adjustY">-4</param>
-			<param name="secondsX">291</param>
-			<param name="secondsY">252</param>
+			<param name="secondsX">340</param>
+			<param name="secondsY">202</param>
+			<param name="amPmOffsetX">-4</param>
+			<param name="amPmOffsetY">10</param>
 		</drawable>
 
 		<drawable id="MoveBar" class="MoveBar">
 			<param name="x">88</param>
 			<param name="y">286</param>
-			<param name="width">192</param>
+			<param name="width">246</param>
 			<param name="height">13</param>
 			<param name="separator">4</param>
 		</drawable>
@@ -68,8 +70,8 @@
 			<param name="adjustY">-4</param>
 			<param name="timeY">179</param>
 			<param name="lineY">230</param>
-			<!-- Allow room for Chinese date -->	
-			<param name="lineWidth">230</param>
+			<!-- Allow room for Chinese date -->
+			<param name="lineWidth">280</param>
 			<!-- param name="lineStroke">2</param -->	
 			<param name="dataY">258</param>
 			<param name="dataLeft">105</param>

--- a/resources-semiround-215x180-ciq_1.x/layouts/layout.xml
+++ b/resources-semiround-215x180-ciq_1.x/layouts/layout.xml
@@ -50,8 +50,8 @@
 	</drawable>
 
 	<drawable id="Time" class="ThickThinTime">
-		<param name="secondsX">147</param>
-		<param name="secondsY">109</param>
+		<param name="secondsX">174</param>
+		<param name="secondsY">88</param>
 		
 		<!-- Partial updates not supported -->		
 		<!-- param name="secondsClipY">117</param-->
@@ -59,12 +59,13 @@
 		<!-- param name="secondsClipHeight">15</param-->
 
 		<param name="adjustY">1</param>
+		<param name="amPmOffsetY">1</param>
 	</drawable>
 
 	<drawable id="MoveBar" class="MoveBar">
 		<param name="x">46</param>
 		<param name="y">126</param>
-		<param name="width">93</param>
+		<param name="width">127</param>
 		<param name="height">7</param>
 		<param name="separator">3</param>
 	</drawable>

--- a/resources-semiround-215x180/layouts/layout.xml
+++ b/resources-semiround-215x180/layouts/layout.xml
@@ -45,8 +45,8 @@
 	</drawable>
 
 	<drawable id="Time" class="ThickThinTime">
-		<param name="secondsX">147</param>
-		<param name="secondsY">109</param>
+		<param name="secondsX">174</param>
+		<param name="secondsY">88</param>
 		
 		<!-- Partial updates not supported -->		
 		<!-- param name="secondsClipY">117</param-->
@@ -54,12 +54,13 @@
 		<!-- param name="secondsClipHeight">15</param-->
 
 		<param name="adjustY">1</param>
+		<param name="amPmOffsetY">1</param>
 	</drawable>
 
 	<drawable id="MoveBar" class="MoveBar">
 		<param name="x">46</param>
 		<param name="y">126</param>
-		<param name="width">93</param>
+		<param name="width">127</param>
 		<param name="height">7</param>
 		<param name="separator">3</param>
 	</drawable>

--- a/resources/layouts/layout.xml
+++ b/resources/layouts/layout.xml
@@ -46,17 +46,19 @@
 		</drawable>
 
 		<drawable id="Time" class="ThickThinTime">
-			<param name="secondsX">167</param>
-			<param name="secondsY">145</param>
-			<param name="secondsClipY">157</param>
+			<param name="secondsX">198</param>
+			<param name="secondsY">117</param>
+			<param name="secondsClipY">129</param>
 			<param name="secondsClipWidth">26</param>
 			<param name="secondsClipHeight">17</param>
+			<param name="amPmOffsetX">-2</param>
+			<param name="amPmOffsetY">2</param>
 		</drawable>
 
 		<drawable id="MoveBar" class="MoveBar">
 			<param name="x">48</param>
 			<param name="y">164</param>
-			<param name="width">110</param>
+			<param name="width">148</param>
 			<param name="height">9</param>
 			<param name="separator">3</param>
 		</drawable>

--- a/source/DataFields.mc
+++ b/source/DataFields.mc
@@ -643,7 +643,7 @@ class DataFields extends Ui.Drawable {
 		if (tomorrow) {
 			now = now.add(new Time.Duration(24 * 60 * 60));
 		}
-		var d = Gregorian.info(Time.now(), Time.FORMAT_SHORT);
+		var d = Gregorian.info(now, Time.FORMAT_SHORT);
 		var rad = Math.PI / 180.0d;
 		var deg = 180.0d / Math.PI;
 		

--- a/source/MoveBar.mc
+++ b/source/MoveBar.mc
@@ -6,6 +6,7 @@ using Toybox.Graphics;
 
 class MoveBar extends Ui.Drawable {
 
+	private var mAdjustX = 0;
 	private var mX, mY, mBaseWidth, mHeight, mSeparator;
 	private var mTailWidth;	
 
@@ -31,7 +32,10 @@ class MoveBar extends Ui.Drawable {
 	function initialize(params) {
 		Drawable.initialize(params);
 		
-		mX = params[:x];
+		if (params[:adjustX] != null) {
+			mAdjustX = params[:adjustX];
+		}
+		mX = params[:x] + mAdjustX;
 		mY = params[:y];
 		mBaseWidth = params[:width]; // mCurrentWidth calculated at start of draw(), when DC is available.
 		mHeight = params[:height];
@@ -61,7 +65,7 @@ class MoveBar extends Ui.Drawable {
 
 		// Calculate current width here, now that DC is accessible.
 		// Balance head/tail positions in full width mode.
-		mCurrentWidth = mIsFullWidth ? (dc.getWidth() - (2 * mX) + mTailWidth) : mBaseWidth;
+		mCurrentWidth = mIsFullWidth ? (dc.getWidth() - (2 * mX) + mTailWidth - mAdjustX) : mBaseWidth;
 
 		// #21 Force unbuffered drawing on fr735xt (CIQ 2.x) to reduce memory usage.
 		if ((Graphics has :BufferedBitmap) && (Sys.getDeviceSettings().screenShape != Sys.SCREEN_SHAPE_SEMI_ROUND)) {
@@ -168,7 +172,7 @@ class MoveBar extends Ui.Drawable {
 		var numBars = ActivityMonitor.MOVE_BAR_LEVEL_MAX - ActivityMonitor.MOVE_BAR_LEVEL_MIN;
 
 		// Subtract tail width, and total separator width.
-		var availableWidth = mCurrentWidth - mTailWidth - ((numBars - 1) * mSeparator);
+		var availableWidth = mCurrentWidth - mTailWidth - ((numBars - 1) * mSeparator) - mAdjustX;
 
 		var barWidth = availableWidth / (numBars + /* First bar is double width */ 1);
 


### PR DESCRIPTION
Since we have enough space on the right side I think it's more balances if we have the seconds (and the am/pm) to the right of the minutes. This also leaves the wull width of the move-bar to future features (i.e requests to be able to display some other data instead of the move-bar)