### PR TITLE
Fix Dutch spelling mistakes / literal translations

### DIFF
--- a/resources-dut/strings/strings.xml
+++ b/resources-dut/strings/strings.xml
@@ -15,7 +15,7 @@
 	<string id="LocalTimeInCityTitle">Voeg Lokale Tijd In Stad Toe (Beta)</string>
 	<string id="MoveBarStyleTitle">Beweeg Balk Stijl</string>
 	<string id="HideSecondsTitle">Verberg Seconden</string>
-	<string id="HideHoursLeadingZeroTitle">Verberg Eerste Nul Bij Uuren</string>
+	<string id="HideHoursLeadingZeroTitle">Verberg Eerste Nul Bij Uren</string>
 	<string id="OWMKeyOverride">OpenWeatherMap API Key Override</string><!-- TODO_TRANSLATE -->
 
 	<string id="FieldCountTitle">Hoeveelheid Datavelden</string>


### PR DESCRIPTION
Some small spelling corrections for the Dutch translation. 
- 'Notificaties' is a too literal translation. 'Meldingen' is more common in Dutch.
 - Fixed extra 'e' in 'Weer'
 - Fixed extra 'u' in 'Uren'
 
This includes the corrections of #190 

Thank you for making this project open source.